### PR TITLE
I update API query to use myco domain instead of expired onchainmagic.

### DIFF
--- a/lib/getZoraFeeRecipients.tsx
+++ b/lib/getZoraFeeRecipients.tsx
@@ -1,6 +1,6 @@
 const getZoraFeeRecipients = async () => {
   try {
-    const response = await fetch("https://api.onchainmagic.xyz/api/zora/feeRecipients")
+    const response = await fetch("https://api.myco.wtf/api/zora/feeRecipients")
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the API endpoint for retrieving Zora fee recipients to use a new base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->